### PR TITLE
Rethrow errors in Proxy accessors (GH#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ escape codes, just as you would in Node.  That's unlikely to be helpful to you
 on the Web, so you might want `stylizeWithHTML`, which is also exported from the package:
 
 ```js
-inspect({a:1}, {
+inspect({ a: 1 }, {
   compact: false,
   stylize: stylizeWithHTML
-}
+});
 ```
 
 which yields this ugly HTML:
@@ -80,7 +80,7 @@ a function that takes two parameters, a string, and a class name.  The mappings
 from class names to colors is in `inspect.styles`, so start with this:
 
 ```js
-stylizeWithHTML(str, styleType) {
+function stylizeWithHTML(str, styleType) {
   const style = inspect.styles[styleType];
   if (style !== undefined) {
     return `<span style="color:${style};">${str}</span>`;
@@ -89,13 +89,13 @@ stylizeWithHTML(str, styleType) {
 }
 ```
 
-## Known Limiations
+## Known Limitations
 
  - If you want your
    [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
    objects to have their internal object inspected, you may use the `Proxy`
    constructor exported by this project.  That was done mostly for test coverage
-   purposes, it is not recommended for production code.
+   purposes. It is not recommended for production code.
  - [`arguments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
    objects are not treated specially.
    [[bug](https://github.com/hildjj/node-inspect-extracted/issues/1)]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "url": "http://github.com/hildjj/node-inspect-extracted.git"
   },
   "author": "Joe Hildebrand <joe-github@cursive.net>",
+  "contributors": ["Noah May <noahmouse2011@gmail.com>"],
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -1554,7 +1554,6 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
       'special'
     );
   }
-  /* c8 ignore next */
   assert.fail(err.stack);
 }
 

--- a/src/internal/assert.js
+++ b/src/internal/assert.js
@@ -1,7 +1,13 @@
 'use strict';
 
-module.exports = function assert(p) {
+function assert(p) {
   if (!p) {
     throw new Error('Assertion failed');
   }
+}
+
+assert.fail = function fail(message) {
+  throw new Error(message);
 };
+
+module.exports = assert;

--- a/test/internal/test-assert.js
+++ b/test/internal/test-assert.js
@@ -4,3 +4,4 @@ const a = require('../../src/internal/assert');
 const assert = require('assert');
 
 assert.throws(() => a(false));
+assert.throws(() => a.fail('error message'));

--- a/test/internal/test-inspect.js
+++ b/test/internal/test-inspect.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const assert = require('assert');
+const util = require('../../src/inspect.js');
+
+// Errors thrown in accessors are re-thrown
+{
+  const obj = new Proxy({}, {
+    get() {
+      throw new Error('Error message');
+    },
+  });
+
+  assert.throws(() => util.format(obj), { message: 'Error message' });
+}


### PR DESCRIPTION
Closes #14

I put the test in [test-util-inspect.js](https://github.com/hildjj/node-inspect-extracted/compare/main...nmay231:node-inspect-extracted:rethrow-accessor-errors?expand=1#diff-755e2936fb30a27966acf7a34f5e4f73478d2a19a6bed3372586a7421b43d4b1) but I could move it to a new file in `test/internal` or something, if you wish.