### PR TITLE
Include InspectOptions interface

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -10,4 +10,5 @@ export const inspectDefaultOptions = util.inspectDefaultOptions;
 export const stripVTControlCharacters = util.stripVTControlCharacters;
 export const stylizeWithColor = util.stylizeWithColor;
 export const stylizeWithHTML = util.stylizeWithHTML;
+export const InspectOptions = util.InspectOptions;
 export const Proxy = util.Proxy;


### PR DESCRIPTION
Thanks for this lib - just what I needed. 
The  `InspectOptions` interface was missing somehow, added here. I've tested in my IDE, it works.