### PR TITLE
Add `"types"` condition to `"exports"` in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./index.mjs",
   "browser": "./dist/inspect.js",
   "exports": {
+    "types": "./types/util.d.ts",
     "import": "./index.mjs",
     "require": "./dist/inspect.js"
   },


### PR DESCRIPTION
The `package.json` has a `"types"` field which points to `./types/util.d.ts`. But it also has an `"exports"` field. The `"exports"` field, when provided, is supposed to supersede fields like `"main"` and `"browser"`. TypeScript respects this as well, and ignores the `"types"` field when `"exports"` is present.

Due to this, the latest version of TypeScript will ignore the `"types"` field, giving the following error:

> error TS7016: Could not find a declaration file for module 'node-inspect-extracted'. 'node_modules/.pnpm/node-inspect-extracted@3.0.0/node_modules/node-inspect-extracted/index.mjs' implicitly has an 'any' type.

It also follows up with the following message:

> There are types at 'node_modules/node-inspect-extracted/types/util.d.ts', but this result could not be resolved when respecting package.json "exports". The 'node-inspect-extracted' library may need to update its package.json or typings.

This PR resolves this issue by adding a `"types"` condition to the `"exports"` field which matches the existing top-level `"types"` field.