### PR TITLE
Build ESM bundle

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,4 @@
-import util from './dist/inspect.js';
+import util from './dist/inspect.mjs';
 
 export default util;
 

--- a/types/util.d.mts
+++ b/types/util.d.mts
@@ -10,7 +10,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v17.6.0/lib/util.js)
  */
-declare module 'node-inspect-extracted' {
+
     export interface InspectOptions {
         /**
          * If set to `true`, getters are going to be
@@ -328,4 +328,3 @@ declare module 'node-inspect-extracted' {
      * **Do not use in production code! Only use during testing.**
      */
     export const Proxy: new <T>(target: T, handler: ProxyHandler<T>) => T;
-}

--- a/types/util.d.ts
+++ b/types/util.d.ts
@@ -10,7 +10,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v17.6.0/lib/util.js)
  */
-declare module 'node-inspect-extracted' {
+
     export interface InspectOptions {
         /**
          * If set to `true`, getters are going to be
@@ -328,4 +328,3 @@ declare module 'node-inspect-extracted' {
      * **Do not use in production code! Only use during testing.**
      */
     export const Proxy: new <T>(target: T, handler: ProxyHandler<T>) => T;
-}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -2,19 +2,9 @@
 
 const path = require('path');
 
-module.exports = {
+const base = {
   entry: './src/inspect.js',
   mode: 'production',
-  output: {
-    // eslint-disable-next-line no-undef
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'inspect.js',
-    library: {
-      type: 'umd',
-      name: 'util',
-    },
-    globalObject: 'this',
-  },
   module: {
     rules: [
       {
@@ -32,3 +22,31 @@ module.exports = {
   },
   // devtool: 'source-map'
 };
+
+// eslint-disable-next-line no-undef
+const dist = path.resolve(__dirname, 'dist');
+
+module.exports = [{
+  ...base,
+  output: {
+    path: dist,
+    filename: 'inspect.js',
+    library: {
+      type: 'umd',
+      name: 'util',
+    },
+    globalObject: 'this',
+  },
+}, {
+  ...base,
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    path: dist,
+    filename: 'inspect.mjs',
+    library: {
+      type: 'module',
+    },
+  },
+}];


### PR DESCRIPTION
Hi again, my apologies, I think #44 was premature.

While the changes appeased the type export checkers, after testing a bit further I'm still seeing some issues with direct ESM imports and type generation.

---

**1. Type generation / bundling issues**

Tools like [rolldown-plugin-dts](https://github.com/sxzz/rolldown-plugin-dts) don't seem to know what to do with the ambient type declarations since they want a proper module to import from. This surfaces errors like:

```
[MISSING_EXPORT] "InspectOptions" is not exported by "node_modules/.pnpm/node-inspect-extracted@3.3.2/node_modules/node-inspect-extracted/types/util.d.ts"
```

To address this, I unwrapped the type definition files from inside their `declare module` wrappers. I don't _think_ this will break anything since most tooling should still find the exported types, but I'm not 100% confident there.

---
  
**2. ESM import errors**

Imports fail the ESM entry point in environments that don't know how to handle ESM-wrapped CJS.

Minimal repro in a Vite project:

```sh
pnpm create vite@latest esm-test --no-immediate --template vanilla-ts && \
cd esm-test && \
pnpm install && \
pnpm add node-inspect-extracted && \
echo "import { inspect } from 'node-inspect-extracted'" >> src/main.ts && \
echo "export default {optimizeDeps:{exclude:[\"node-inspect-extracted\"],},};" > vite.config.js && \
pnpm vite dev --open
```

The browser console will show an error like:

```txt
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/node-inspect-extracted@3.3.2/node_modules/node-inspect-extracted/dist/inspect.js?v=77140318' does not provide an export named 'default' (at index.mjs:1:8)
```

To address this, I added an ESM output target to the webpack build script.

---

Please feel free to close if you'd rather investigate on your own or ignore, and I'll just work with a fork.

I personally only ever publish ESM versions of my own projects, so I'm not sure I'm bringing much expertise to bear on the unique challenges (indignities?) of dual-package publishing.